### PR TITLE
getvalue -> read

### DIFF
--- a/tractdb_pyramid/views/attachmentview.py
+++ b/tractdb_pyramid/views/attachmentview.py
@@ -80,7 +80,8 @@ def get(request):
     # Return appropriately
     request.response.status_int = 200
     request.response.content_type = result['content_type']
-    request.response.body = result['content'].getvalue()
+    request.response.body = result['content'].read()
+    result['content'].close()
 
     return request.response
 


### PR DESCRIPTION
I get the following error when I try to `get` an image:
```
  File "/Users/epstein/GitHub/tractdb-pyramid/tractdb_pyramid/views/attachmentview.py", line 83, in get
    request.response.body = result['content'].getvalue()
AttributeError: 'ResponseBody' object has no attribute 'getvalue'
```
ResponseBody has a `read` and a `close`, but no `getvalue`: https://github.com/Roger/couchdb-python/blob/master/couchdb/http.py
This change works on my machine and passes the test cases, though I can't explain why `getvalue()` would work for some configurations.