### PR TITLE
consistent return names between documents and attachments

### DIFF
--- a/tractdb_pyramid/views/attachmentview.py
+++ b/tractdb_pyramid/views/attachmentview.py
@@ -124,8 +124,8 @@ def post(request):
     request.response.status_int = 201
 
     return {
-        'id': doc_id,
-        'rev': result['rev']
+        '_id': doc_id,
+        '_rev': result['rev']
     }
 
 
@@ -163,8 +163,8 @@ def put(request):
     request.response.status_int = 200
 
     return {
-        'id': doc_id,
-        'rev': result['rev']
+        '_id': doc_id,
+        '_rev': result['rev']
     }
 
 


### PR DESCRIPTION
`post`ing a `document` returns `_id`, `_rev`.
`post`ing an `attachment` returns `id`, `rev`.

This is annoying.